### PR TITLE
Add Python3.4 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Javascript Frontend: http://benqus.github.io/strategypy-ui/
 Installation
 ------------
 
-System dependencies: python2.7
+System dependencies: python2.7 or python3.4
 
 * ```git clone https://github.com/davide-ceretti/strategypy.git```
 * ```pip install -e .```

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ with open('README.md') as readme_file:
 
 requirements = [
     'websocket-client',
+    'six',
 ]
 
 setup(
@@ -44,5 +45,7 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
     ],
 )

--- a/strategypy/bots/happines_base.py
+++ b/strategypy/bots/happines_base.py
@@ -60,7 +60,8 @@ class Bot():
 
         for direction in directions:
             happiness = self.calc_happiness(directions[direction]['friends'], directions[direction]['enemies'])
-            res.append((happiness, direction))
+            if direction is not None:
+                res.append((happiness, direction))
 
         max_hap = max(res)[0]
 

--- a/strategypy/bots/happiness.py
+++ b/strategypy/bots/happiness.py
@@ -2,7 +2,7 @@ import random
 import sys
 from copy import deepcopy
 
-from happines_base import Bot as HappinessBaseBot
+from .happines_base import Bot as HappinessBaseBot
 
 
 """

--- a/strategypy/components.py
+++ b/strategypy/components.py
@@ -1,5 +1,7 @@
 import random
 
+import six
+
 from strategypy import settings
 
 
@@ -11,7 +13,10 @@ class Player(object):
         self.pk = pk
         self.game = game
         self.bot_class = bot_class
-        self.units = [Unit(self, i) for i in xrange(settings.UNITS)]
+        if six.PY2:
+            self.units = [Unit(self, i) for i in xrange(settings.UNITS)]
+        else:
+            self.units = [Unit(self, i) for i in range(settings.UNITS)]
         self.has_killed = {}
         self.was_killed_by = {}
 
@@ -133,7 +138,10 @@ class Unit(object):
 
     def get_random_location(self):
         X, Y = settings.GRID_SIZE
-        all_cells = {(x, y) for x in xrange(0, X) for y in xrange(0, Y)}
+        if six.PY2:
+            all_cells = {(x, y) for x in xrange(0, X) for y in xrange(0, Y)}
+        else:
+            all_cells = {(x, y) for x in range(0, X) for y in range(0, Y)}
         occupied_cells = self.player.game.occupied_cells
         open_cells = all_cells - set(occupied_cells.keys())
         return random.sample(open_cells, 1)[0]

--- a/strategypy/consolefe.py
+++ b/strategypy/consolefe.py
@@ -1,7 +1,10 @@
+from __future__ import print_function
 import json
 import sys
 import copy
 from optparse import OptionParser
+
+import six
 
 
 def print_frames(output_dict):
@@ -12,7 +15,7 @@ def print_frames(output_dict):
         for i in range(grid_size[0])
     ]
 
-    print '-' * (grid_size[1] + 2)
+    print('-' * (grid_size[1] + 2))
 
     for frame in output_dict['frames']:
         grid = copy.deepcopy(empty_grid)
@@ -22,8 +25,8 @@ def print_frames(output_dict):
                 grid[x][y] = player_pk
 
         for row in grid:
-            print '|' + ''.join(row) + '|'
-        print '-' * (grid_size[1] + 2)
+            print('|' + ''.join(row) + '|')
+        print('-' * (grid_size[1] + 2))
 
 
 def print_summary(output_dict):
@@ -36,27 +39,27 @@ def print_summary(output_dict):
     initial_frame = output_dict['frames'][0]
     last_frame = output_dict['frames'][-1]
 
-    initial_count = sum((len(x) for x in initial_frame.itervalues()))
-    final_count = sum((len(x) for x in last_frame.itervalues()))
+    initial_count = sum((len(x) for x in six.itervalues(initial_frame)))
+    final_count = sum((len(x) for x in six.itervalues(last_frame)))
 
     winner = None if winner is None else players[str(winner)]
     if winner is None:
-        print 'No player won and the game ended in {} turns'.format(turns)
+        print('No player won and the game ended in {} turns'.format(turns))
     else:
-        print 'Player {} won in {} turns'.format(winner, turns)
-    print 'Initial unit count: {}'.format(initial_count)
-    print 'Final unit count: {}'.format(final_count)
+        print('Player {} won in {} turns'.format(winner, turns))
+    print('Initial unit count: {}'.format(initial_count))
+    print('Final unit count: {}'.format(final_count))
 
     for player in all_players.values():
-        print 'Player {} killed: '.format(player['name']),
+        print('Player {} killed: '.format(player['name']), end="")
         for killed_player, num_times in player['has_killed'].items():
-            print '{} x {}, '.format(killed_player, num_times),
-        print
+            print('{} x {}, '.format(killed_player, num_times), end="")
+        print()
     for player in all_players.values():
-        print 'Player {} was killed by: '.format(player['name']),
+        print('Player {} was killed by: '.format(player['name']), end="")
         for killed_player, num_times in player['was_killed_by'].items():
-            print '{} x {}, '.format(killed_player, num_times),
-        print
+            print('{} x {}, '.format(killed_player, num_times), end="")
+        print()
 
 
 if __name__ == "__main__":

--- a/strategypy/game.py
+++ b/strategypy/game.py
@@ -1,6 +1,8 @@
 from random import shuffle
 import json
 
+import six
+
 from strategypy import settings
 from strategypy.components import Player
 from strategypy.api import make_local_bot
@@ -113,10 +115,14 @@ class Game(object):
             player_units = current_data[player_pk].values()
 
             killers = []
+            if six.PY2:
+                range_func = xrange
+            else:
+                range_func = range
 
             allies, enemies = 0, 0
-            for xd in xrange(-1, 2):
-                for yd in xrange(-1, 2):
+            for xd in range_func(-1, 2):
+                for yd in range_func(-1, 2):
                     ox = x + xd
                     oy = y + yd
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -247,5 +247,5 @@ class TestSpawning(unittest.TestCase):
         )
         units = sorted(list(units))
 
-        expected = [[x, y] for x in xrange(3) for y in xrange(4)]
+        expected = [[x, y] for x in range(3) for y in range(4)]
         self.assertListEqual(units, expected)

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 # Usage:
 # tox
 # tox -e py27
+# tox -e py34
 # tox -e flake8
 # tox -e py27 -- -k test_player_info
 
 [tox]
 toxversion = 1.8.1
-envlist = py27
+envlist = py27, py34
 setenv =
     PYTHONPATH = {toxinidir}
 


### PR DESCRIPTION
Compatibility for Python3 to strategypy.
`./play.sh` currently works for both python2 and python3 with this changes
Currently tox passes tests on both python2 and 3:

```
raulcd@strategypy (feature/python3_compatibility) $ tox
GLOB sdist-make: /Users/raulcd/strategypy/setup.py
py27 inst-nodeps: /Users/raulcd/strategypy/.tox/dist/strategypy-0.2.1.zip
py27 runtests: PYTHONHASHSEED='2906404891'
py27 runtests: commands[0] | py.test -s
================================================================================ test session starts ================================================================================
platform darwin -- Python 2.7.9 -- py-1.4.26 -- pytest-2.6.4
collected 19 items

tests/test_integration.py ...................

============================================================================= 19 passed in 0.16 seconds =============================================================================
py34 inst-nodeps: /Users/raulcd/strategypy/.tox/dist/strategypy-0.2.1.zip
py34 runtests: PYTHONHASHSEED='2906404891'
py34 runtests: commands[0] | py.test -s
================================================================================ test session starts ================================================================================
platform darwin -- Python 3.4.2 -- py-1.4.26 -- pytest-2.6.4
collected 19 items

tests/test_integration.py ...................

============================================================================= 19 passed in 0.18 seconds =============================================================================
______________________________________________________________________________________ summary ______________________________________________________________________________________
  py27: commands succeeded
  py34: commands succeeded
  congratulations :)
```
